### PR TITLE
Faster prune for cache_mem

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: cachem
-Version: 1.0.1
+Version: 1.0.1.9000
 Title: Cache R Objects with Automatic Pruning
 Description: Key-value stores with automatic pruning. Caches can limit
     either their total size or the age of the oldest object (or both),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+cachem 1.0.1.9000
+============
+
+* Closed #4: Sped up pruning for `cache_mem`. (#5)
+
 cachem 1.0.1
 ============
 

--- a/R/cache-memory.R
+++ b/R/cache-memory.R
@@ -306,12 +306,30 @@ cache_mem <- function(
   }
 
   object_info_ = function() {
-    keys <- cache_$keys()
+    objs <- cache_$as_list()
+    len  <- length(objs)
+
+    # Pre-allocate these vectors and fill them with a for loop. This is faster
+    # than calling vapply() multiple times to extract each one.
+    key   <- character(len)
+    size  <- numeric(len)
+    mtime <- numeric(len)
+    atime <- numeric(len)
+
+    for (i in seq_len(len)) {
+      obj <- objs[[i]]
+
+      key[i]   <- obj$key
+      size[i]  <- obj$size
+      mtime[i] <- obj$mtime
+      atime[i] <- obj$atime
+    }
+
     data.frame(
-      key   = keys,
-      size  = vapply(keys, function(key) cache_$get(key)$size,  0),
-      mtime = vapply(keys, function(key) cache_$get(key)$mtime, 0),
-      atime = vapply(keys, function(key) cache_$get(key)$atime, 0),
+      key   = key,
+      size  = size,
+      mtime = mtime,
+      atime = atime,
       stringsAsFactors = FALSE
     )
   }

--- a/tests/testthat/test-cache-mem.R
+++ b/tests/testthat/test-cache-mem.R
@@ -48,7 +48,7 @@ test_that("cache_mem: pruning respects max_n", {
   d$set("c", rnorm(100))
   d$set("d", rnorm(100))
   d$set("e", rnorm(100))
-  expect_setequal(d$keys(), c("c", "d", "e"))
+  expect_identical(sort(d$keys()), c("c", "d", "e"))
 })
 
 test_that("cache_mem: pruning respects max_size", {
@@ -56,7 +56,7 @@ test_that("cache_mem: pruning respects max_size", {
   d$set("a", rnorm(100))
   d$set("b", rnorm(100))
   d$set("c", 1)
-  expect_setequal(d$keys(), c("c"))
+  expect_identical(sort(d$keys()), c("c"))
   d$set("d", rnorm(100))
   # Objects are pruned with oldest first, so even though "c" would fit in the
   # cache, it is removed after adding "d" (and "d" is removed as well because it
@@ -64,7 +64,7 @@ test_that("cache_mem: pruning respects max_size", {
   expect_length(d$keys(), 0)
   d$set("e", 2)
   d$set("f", 3)
-  expect_setequal(d$keys(), c("e", "f"))
+  expect_identical(sort(d$keys()), c("e", "f"))
 })
 
 test_that("cache_mem: pruning respects both max_n and max_size", {
@@ -82,5 +82,5 @@ test_that("cache_mem: pruning respects both max_n and max_size", {
   d$set("g", 1)
   d$set("h", 1)
   d$set("i", 1)
-  expect_setequal(d$keys(), c("g", "h", "i"))
+  expect_identical(sort(d$keys()), c("g", "h", "i"))
 })

--- a/tests/testthat/test-cache-mem.R
+++ b/tests/testthat/test-cache-mem.R
@@ -40,30 +40,31 @@ test_that("cache_mem: handling missing values", {
 })
 
 
-
 test_that("cache_mem: pruning respects max_n", {
   d <- cache_mem(max_n = 3)
-  d$set("a", rnorm(100))
-  d$set("b", rnorm(100))
-  d$set("c", rnorm(100))
-  d$set("d", rnorm(100))
-  d$set("e", rnorm(100))
+  # NOTE: The short delays after each item are meant to tests more reliable on
+  # CI systems.
+  d$set("a", rnorm(100)); Sys.sleep(0.001)
+  d$set("b", rnorm(100)); Sys.sleep(0.001)
+  d$set("c", rnorm(100)); Sys.sleep(0.001)
+  d$set("d", rnorm(100)); Sys.sleep(0.001)
+  d$set("e", rnorm(100)); Sys.sleep(0.001)
   expect_identical(sort(d$keys()), c("c", "d", "e"))
 })
 
 test_that("cache_mem: pruning respects max_size", {
   d <- cache_mem(max_size = 200)
-  d$set("a", rnorm(100))
-  d$set("b", rnorm(100))
-  d$set("c", 1)
+  d$set("a", rnorm(100)); Sys.sleep(0.001)
+  d$set("b", rnorm(100)); Sys.sleep(0.001)
+  d$set("c", 1);          Sys.sleep(0.001)
   expect_identical(sort(d$keys()), c("c"))
-  d$set("d", rnorm(100))
+  d$set("d", rnorm(100)); Sys.sleep(0.001)
   # Objects are pruned with oldest first, so even though "c" would fit in the
   # cache, it is removed after adding "d" (and "d" is removed as well because it
   # doesn't fit).
   expect_length(d$keys(), 0)
-  d$set("e", 2)
-  d$set("f", 3)
+  d$set("e", 2);          Sys.sleep(0.001)
+  d$set("f", 3);          Sys.sleep(0.001)
   expect_identical(sort(d$keys()), c("e", "f"))
 })
 
@@ -73,14 +74,14 @@ test_that("cache_mem: pruning respects both max_n and max_size", {
   # like 1:100 will be stored very efficiently by R's ALTREP, and won't exceed
   # the max_size. We want each of these objects to exceed max_size so that
   # they'll be pruned.
-  d$set("a", rnorm(100))
-  d$set("b", rnorm(100))
-  d$set("c", rnorm(100))
-  d$set("d", rnorm(100))
-  d$set("e", rnorm(100))
-  d$set("f", 1)   # This object is small and shouldn't be pruned.
-  d$set("g", 1)
-  d$set("h", 1)
-  d$set("i", 1)
+  d$set("a", rnorm(100)); Sys.sleep(0.001)
+  d$set("b", rnorm(100)); Sys.sleep(0.001)
+  d$set("c", rnorm(100)); Sys.sleep(0.001)
+  d$set("d", rnorm(100)); Sys.sleep(0.001)
+  d$set("e", rnorm(100)); Sys.sleep(0.001)
+  d$set("f", 1);          Sys.sleep(0.001)
+  d$set("g", 1);          Sys.sleep(0.001)
+  d$set("h", 1);          Sys.sleep(0.001)
+  d$set("i", 1);          Sys.sleep(0.001)
   expect_identical(sort(d$keys()), c("g", "h", "i"))
 })


### PR DESCRIPTION
Closes #4. This speeds up the pruning for `cache_mem()`.

It may be possible to have even faster pruning in the future, but it will probably require new data structures to store the metadata.