### PR TITLE
Allow `_` and `-` in keys

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: cachem
-Version: 1.0.4
+Version: 1.0.4.9000
 Title: Cache R Objects with Automatic Pruning
 Description: Key-value stores with automatic pruning. Caches can limit
     either their total size or the age of the oldest object (or both),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+cachem 1.0.4.9000
+============
+
+* `cache_mem()` and `cache_disk()` now allow `-` and `_` (hyphen and underscore) characters in the keys.
+
 cachem 1.0.4
 ============
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,6 +31,6 @@ absolute_path <- function(path) {
 }
 
 validate_key <- function(key) {
-  # This C function does the same as `grepl("[^a-z0-9]")`, but faster.
+  # This C function does the same as `grepl("[^a-z0-9_-]")`, but faster.
   .Call(C_validate_key, key)
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -12,7 +12,7 @@ SEXP C_validate_key(SEXP key_r) {
   }
 
   const char* s = R_CHAR(key_c);
-  char cset[] = "1234567890abcdefghijklmnopqrstuvwxyz";
+  char cset[] = "1234567890abcdefghijklmnopqrstuvwxyz_-";
   int i = strspn(s, cset);
   if (i != strlen(s)) {
     Rf_error("Invalid key: %s. Only lowercase letters and numbers are allowed.", s);

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,17 @@
+
+test_that("validate_key", {
+  expect_true(validate_key("e"))
+  expect_true(validate_key("abc"))
+  expect_true(validate_key("abcd123-_"))
+  expect_true(validate_key("-"))
+  expect_true(validate_key("_"))
+
+  expect_error(validate_key("a.b"))
+  expect_error(validate_key("a,b"))
+  expect_error(validate_key("é"))
+  expect_error(validate_key("ABC"))
+  expect_error(validate_key("_A"))
+  expect_error(validate_key("!"))
+  expect_error(validate_key("a b"))
+  expect_error(validate_key("ab\n"))
+})


### PR DESCRIPTION
Closes https://github.com/rstudio/shiny/issues/3306.

This allows `-` and `_` to be used in cache keys.

I could imagine it being useful to allow users to allow any string to be used for `cache_mem()`. Then it would act as a general key-value store with pruning.

cc: @vspinu	

