### PR TITLE
Show proper default value for `max_age` param to `cache_mem()`

### DIFF
--- a/R/cache-mem.R
+++ b/R/cache-mem.R
@@ -117,6 +117,9 @@
 #'     }
 #'   }
 #'
+#' @param max_size Maximum size of the cache, in bytes. If the cache exceeds
+#'   this size, cached objects will be removed according to the value of the
+#'   `evict`. Use `Inf` for no size limit. The default is 512 megabytes.
 #' @inheritParams cache_disk
 #'
 #' @return A memory caching object, with class `cache_mem`.

--- a/man/cache_mem.Rd
+++ b/man/cache_mem.Rd
@@ -16,7 +16,7 @@ cache_mem(
 \arguments{
 \item{max_size}{Maximum size of the cache, in bytes. If the cache exceeds
 this size, cached objects will be removed according to the value of the
-\code{evict}. Use \code{Inf} for no size limit. The default is 1 gigabyte.}
+\code{evict}. Use \code{Inf} for no size limit. The default is 512 megabytes.}
 
 \item{max_age}{Maximum age of files in cache before they are evicted, in
 seconds. Use \code{Inf} for no age limit.}


### PR DESCRIPTION
`cache_mem()` has been inheriting parameter documentation from `cache_disk()`, however the default value for the `max_age` parameter differs between the two.

This adds explicit documentation for `cache_mem()`'s version of the parameter with the correct 512 MB default value.