### PR TITLE
Make sure cache objects don't affect RNG state

### DIFF
--- a/R/cache-disk.R
+++ b/R/cache-disk.R
@@ -250,7 +250,7 @@ cache_disk <- function(
   # so that, in the case where multiple cache_disk objects that point to the
   # same directory are created and discarded after just a few uses each,
   # pruning will still occur.
-  prune_throttle_counter_ <- sample.int(prune_rate_, 1) - 1
+  prune_throttle_counter_ <- with_private_seed(sample.int(prune_rate_, 1) - 1)
   prune_last_time_        <- as.numeric(Sys.time())
 
   if (destroy_on_finalize_) {

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -1,0 +1,16 @@
+test_that("cache objects don't affect RNG state", {
+  # https://github.com/r-lib/cachem/issues/29
+  cm <- cache_mem()
+  cd <- cache_disk()
+
+  set.seed(42)
+  target <- sample(99999, 1)
+
+  set.seed(42)
+  cm$set("x",letters)
+  expect_identical(sample(99999, 1), target)
+
+  set.seed(42)
+  cd$set("x",letters)
+  expect_identical(sample(99999, 1), target)
+})


### PR DESCRIPTION
Closes #29. I based this implementation on Shiny's `withPrivateSeed()` function: https://github.com/rstudio/shiny/blob/78d77ce37/R/utils.R#L54-L88

The one thing I didn't bring over was the call to `httpuv::getRNGState()`. We probably need something like this in cases where an Rcpp function (in C++) calls this R code, though I don't know for sure right now.. If we implement this, we'll want to do it without bringing in an httpuv dependency or even Rcpp -- we'll want to implement it with C in the src/ directory.