### PR TITLE
Add support for custom serialization functions to disk

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     fastmap
 Suggests:
     testthat
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Roxygen: list(markdown = TRUE)
 Config/Needs/routine:
     lobstr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # cachem (development version)
 
+* `cache_disk()` gains a `read_fn`, `write_fn` and `extension` arguments, to allow specifying custom formats for serializing object to disk. (@jimhester)
 
 # cachem 1.0.6
 

--- a/R/cache-disk.R
+++ b/R/cache-disk.R
@@ -198,14 +198,14 @@
 #' @export
 cache_disk <- function(
   dir = NULL,
-  read_fn = NULL,
-  write_fn = NULL,
-  extension = ".rds",
   max_size = 1024 * 1024 ^ 2,
   max_age = Inf,
   max_n = Inf,
   evict = c("lru", "fifo"),
   destroy_on_finalize = FALSE,
+  read_fn = NULL,
+  write_fn = NULL,
+  extension = ".rds",
   missing = key_missing(),
   prune_rate = 20,
   warn_ref_objects = FALSE,

--- a/README.Rmd
+++ b/README.Rmd
@@ -236,6 +236,21 @@ gc()
 dir.exists(cachedir)
 ```
 
+#### Using custom serialization functions
+
+It is possible to use custom serialization functions rather than the default of `writeRDS()` and `readRDS()` with the `write_fn`, `read_fn` and `extension` arguments respectively. This could be used to use alternative serialization formats like [qs](https://github.com/traversc/qs), or specialized object formats [fst](http://www.fstpackage.org/fst/) or parquet.
+
+```{r}
+library(qs)
+
+d <- cache_disk(read_fn = qs::qread, write_fn = qs::qsave, extension = ".qs")
+
+d$set("a", list(1, 2, 3))
+
+cachedir <- d$info()$dir
+dir(cachedir)
+d$get("a")
+```
 
 ## Cache API
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 
-  - [cachem](#cachem)
-      - [Installation](#installation)
-      - [Usage](#usage)
-      - [Cache types](#cache-types)
-          - [`cache_mem()`](#cache_mem)
-          - [`cache_disk()`](#cache_disk)
-      - [Cache API](#cache-api)
-          - [Limitations of serialized
-            objects](#limitations-of-serialized-objects)
-          - [Read-only caches](#read-only-caches)
-      - [Pruning](#pruning)
-      - [Layered caches](#layered-caches)
+-   [cachem](#cachem)
+    -   [Installation](#installation)
+    -   [Usage](#usage)
+    -   [Cache types](#cache-types)
+        -   [`cache_mem()`](#cache_mem)
+        -   [`cache_disk()`](#cache_disk)
+    -   [Cache API](#cache-api)
+    -   [Pruning](#pruning)
+    -   [Layered caches](#layered-caches)
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
@@ -30,9 +27,9 @@ so that they won’t have unbounded growth.
 The cache objects in **cachem** differ from some other key-value stores
 in the following ways:
 
-  - The cache objects provide automatic pruning so that they remain
+-   The cache objects provide automatic pruning so that they remain
     within memory limits.
-  - Fetching a non-existing object returns a sentinel value. An
+-   Fetching a non-existing object returns a sentinel value. An
     alternative is to simply return `NULL`. This is what R lists and
     environments do, but it is ambiguous whether the value really is
     `NULL`, or if it is not present. Another alternative is to throw an
@@ -112,16 +109,14 @@ The reason for doing this (instead of calling `$exists(key)` and then
 race condition: the object could be removed from the cache between the
 `exists()` and `get()` calls. For example:
 
-  - If multiple R processes have `cache_disk`s that share the same
+-   If multiple R processes have `cache_disk`s that share the same
     directory, one process could remove an object from the cache in
     between the `exists()` and `get()` calls in another process,
     resulting in an error.
-  - If you use a `cache_mem` with a `max_age`, it’s possible for an
+-   If you use a `cache_mem` with a `max_age`, it’s possible for an
     object to be present when you call `exists()`, but for its age to
     exceed `max_age` by the time `get()` is called. In that case, the
     `get()` will return a `key_missing()` object.
-
-<!-- end list -->
 
 ``` r
 # Avoid this pattern, due to a potential race condition!
@@ -137,7 +132,7 @@ disk cache.
 
 ### `cache_mem()`
 
-The memory cache stores objects in memory, by simply keeping a
+The memory cache stores stores objects in memory, by simply keeping a
 reference to each object. To create a memory cache:
 
 ``` r
@@ -184,9 +179,9 @@ to the size of cache, and the cache *thinks* it has 200MB of contents,
 the actual amount of memory consumed could be less than 200MB.
 
 <details>
-
-<summary>Demonstration of memory over-counting from
-`object.size()`</summary>
+<summary>
+Demonstration of memory over-counting from `object.size()`
+</summary>
 
 ``` r
 # Create a and b which both contain the same numeric vector.
@@ -206,7 +201,7 @@ object.size(m$get("b"))
 #> 800224 bytes
 ```
 
-For reference, lobstr::obj\_size can detect shared objects, and knows
+For reference, lobstr::obj_size can detect shared objects, and knows
 that these objects share most of their memory.
 
 ``` r
@@ -216,10 +211,10 @@ lobstr::obj_size(list(m$get("a"), m$get("b")))
 #> 800,408 B
 ```
 
-However, lobstr is not on CRAN, and if obj\_size() were used to find the
+However, lobstr is not on CRAN, and if obj_size() were used to find the
 incremental memory used when an object was added to the cache, it would
 have to walk all objects in the cache every time a single object is
-added. For these reasons, cache\_mem uses `object.size()` to compute the
+added. For these reasons, cache_mem uses `object.size()` to compute the
 object sizes.
 
 </details>
@@ -313,40 +308,71 @@ gc()
 dir.exists(cachedir)
 ```
 
+#### Using custom serialization functions
+
+It is possible to use custom serialization functions rather than the
+default of `writeRDS()` and `readRDS()` with the `write_fn`, `read_fn`
+and `extension` arguments respectively. This could be used to use
+alternative serialization formats like
+[qs](https://github.com/traversc/qs), or specialized object formats
+[fst](http://www.fstpackage.org/fst/) or parquet.
+
+``` r
+library(qs)
+#> qs v0.25.3.
+
+d <- cache_disk(read_fn = qs::qread, write_fn = qs::qsave, extension = ".qs")
+
+d$set("a", list(1, 2, 3))
+
+cachedir <- d$info()$dir
+dir(cachedir)
+#> [1] "a.qs"
+d$get("a")
+#> [[1]]
+#> [1] 1
+#> 
+#> [[2]]
+#> [1] 2
+#> 
+#> [[3]]
+#> [1] 3
+```
+
 ## Cache API
 
 `cache_mem()` and `cache_disk()` support all of the methods listed
 below. If you want to create a compatible caching object, it must have
 at least the `get()` and `set()` methods:
 
-  - `get(key, missing = missing_)`: Get the object associated with
+-   `get(key, missing = missing_)`: Get the object associated with
     `key`. The `missing` parameter allows customized behavior if the key
     is not present: it actually is an expression which is evaluated when
     there is a cache miss, and it could return a value or throw an
     error.
-  - `set(key, value)`: Set a key to a value.
-  - `exists(key)`: Check whether a particular key exists in the cache.
-  - `remove(key)`: Remove a key-value from the cache.
+-   `set(key, value)`: Set a key to a value.
+-   `exists(key)`: Check whether a particular key exists in the cache.
+-   `remove(key)`: Remove a key-value from the cache.
 
 Some optional methods:
 
-  - `reset()`: Clear all objects from the cache.
-  - `keys()`: Return a character vector of all keys in the cache.
-  - `prune()`: Prune the cache. (Some types of caches may not prune on
+-   `reset()`: Clear all objects from the cache.
+-   `keys()`: Return a character vector of all keys in the cache.
+-   `prune()`: Prune the cache. (Some types of caches may not prune on
     every access, and may temporarily grow past their limits, until the
     next pruning is triggered automatically, or manually with this
     function.)
-  - `size()`: Return the number of objects in the cache.
-  - `size()`: Return the number of objects in the cache.
+-   `size()`: Return the number of objects in the cache.
+-   `size()`: Return the number of objects in the cache.
 
 For these methods:
 
-  - `key`: can be any string with lowercase letters, numbers, underscore
+-   `key`: can be any string with lowercase letters, numbers, underscore
     (`_`) and hyphen (`-`). Some storage backends may not be handle very
     long keys well. For example, with a `cache_disk()`, the key is used
     as a filename, and on some filesystems, very filenames may hit
     limits on path lengths.
-  - `value`: can be any R object, with some exceptions noted below.
+-   `value`: can be any R object, with some exceptions noted below.
 
 #### Limitations of serialized objects
 
@@ -408,10 +434,10 @@ specified by `max_size`. When the size of objects in the cache exceeds
 When objects are pruned from the cache, which ones are removed is
 determined by the eviction policy, `evict`:
 
-  - **`lru`**: The least-recently-used objects will be removed from the
+-   **`lru`**: The least-recently-used objects will be removed from the
     cache, until it fits within the limit. This is the default and is
     appropriate for most cases.
-  - **`fifo`**: The oldest objects will be removed first.
+-   **`fifo`**: The oldest objects will be removed first.
 
 It is also possible to set the maximum number of items that can be in
 the cache, with `max_n`. By default this is set to `Inf`, or no limit.

--- a/man/cache_disk.Rd
+++ b/man/cache_disk.Rd
@@ -6,14 +6,14 @@
 \usage{
 cache_disk(
   dir = NULL,
-  extension = ".rds",
-  read_fn = NULL,
-  write_fn = NULL,
   max_size = 1024 * 1024^2,
   max_age = Inf,
   max_n = Inf,
   evict = c("lru", "fifo"),
   destroy_on_finalize = FALSE,
+  read_fn = NULL,
+  write_fn = NULL,
+  extension = ".rds",
   missing = key_missing(),
   prune_rate = 20,
   warn_ref_objects = FALSE,
@@ -23,14 +23,6 @@ cache_disk(
 \arguments{
 \item{dir}{Directory to store files for the cache. If \code{NULL} (the default) it
 will create and use a temporary directory.}
-
-\item{extension}{The file extension to use for files on disk.}
-
-\item{read_fn}{The function used to read the values from disk. If \code{NULL}
-(the default) it will use \code{readRDS}.}
-
-\item{write_fn}{The function used to write the values from disk. If \code{NULL}
-(the default) it will use \code{writeRDS}.}
 
 \item{max_size}{Maximum size of the cache, in bytes. If the cache exceeds
 this size, cached objects will be removed according to the value of the
@@ -50,6 +42,14 @@ when a cache pruning occurs. Currently, \code{"lru"} and \code{"fifo"} are suppo
 garbage collected, the cache directory and all objects inside of it will be
 deleted from disk. If \code{FALSE} (the default), it will do nothing when
 finalized.}
+
+\item{read_fn}{The function used to read the values from disk. If \code{NULL}
+(the default) it will use \code{readRDS}.}
+
+\item{write_fn}{The function used to write the values from disk. If \code{NULL}
+(the default) it will use \code{writeRDS}.}
+
+\item{extension}{The file extension to use for files on disk.}
 
 \item{missing}{A value to return when \code{get(key)} is called but the key is not
 present in the cache. The default is a \code{\link[=key_missing]{key_missing()}} object. It is

--- a/man/cache_disk.Rd
+++ b/man/cache_disk.Rd
@@ -6,6 +6,9 @@
 \usage{
 cache_disk(
   dir = NULL,
+  extension = ".rds",
+  read_fn = NULL,
+  write_fn = NULL,
   max_size = 1024 * 1024^2,
   max_age = Inf,
   max_n = Inf,
@@ -20,6 +23,14 @@ cache_disk(
 \arguments{
 \item{dir}{Directory to store files for the cache. If \code{NULL} (the default) it
 will create and use a temporary directory.}
+
+\item{extension}{The file extension to use for files on disk.}
+
+\item{read_fn}{The function used to read the values from disk. If \code{NULL}
+(the default) it will use \code{readRDS}.}
+
+\item{write_fn}{The function used to write the values from disk. If \code{NULL}
+(the default) it will use \code{writeRDS}.}
 
 \item{max_size}{Maximum size of the cache, in bytes. If the cache exceeds
 this size, cached objects will be removed according to the value of the

--- a/tests/testthat/test-cache-disk.R
+++ b/tests/testthat/test-cache-disk.R
@@ -232,3 +232,14 @@ test_that("Warnings for caching reference objects", {
   expect_silent(d$set("a", function() NULL))
   expect_silent(d$set("a", fastmap()))
 })
+
+test_that("Cache disk can use different formts", {
+  my_write <- function(...) write.csv(..., row.names = FALSE)
+
+  d <- cache_disk(read_fn = read.csv, write_fn = my_write, extension = ".csv")
+
+  mt <- mtcars
+  rownames(mt) <- NULL
+  d$set("mt", mt)
+  expect_equal(d$get("mt"), mt)
+})


### PR DESCRIPTION
This generalizes the reading and writing to allows users to use other
methods of serializing objects to disk.

This may be beneficial if the default methods of `readRDS` and `saveRDS`
are too slow, or if the users want to change the amount of compression
used. It also allows the use of faster serialization methods like fst.

Or for specialized cases where you are always caching one type of object
(like data frames) you can use object specific formats like parquet
files.