### PR TITLE
Fix spurious `nothing to compact` message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ ByteCompile: true
 URL: https://cachem.r-lib.org/, https://github.com/r-lib/cachem
 Imports:
     rlang,
-    fastmap (>= 1.1.1)
+    fastmap (>= 1.1.1.9001)
 Suggests:
     testthat
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: cachem
-Version: 1.0.8
+Version: 1.0.8.9000
 Title: Cache R Objects with Automatic Pruning
 Description: Key-value stores with automatic pruning. Caches can limit
     either their total size or the age of the oldest object (or both),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ ByteCompile: true
 URL: https://cachem.r-lib.org/, https://github.com/r-lib/cachem
 Imports:
     rlang,
-    fastmap (>= 1.1.1.9001)
+    fastmap (>= 1.2.0)
 Suggests:
     testthat
 RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# cachem 1.0.8.9000
+
+* Fixed #47: In some cases, with a `cache_mem`, removing an item could result in the spurious message "nothing to compact" being printed out. (#48)
+
 # cachem 1.0.8
 
 * Fixed #38: With a `cache_mem`, `$reset()` did not fully reset the cache, and calling calling `$prune()` could result in an error. (#39)

--- a/R/cache-mem.R
+++ b/R/cache-mem.R
@@ -554,11 +554,6 @@ cache_mem <- function(
 
     if (DEBUG) stopifnot(total_n_ == length(from_idxs))
 
-    if (total_n_ == 0L) {
-      message("nothing to compact")
-      return()
-    }
-
     new_size <- ceiling(total_n_ * COMPACT_MULT)
 
     # Allocate new vectors for metadata.

--- a/tests/testthat/test-cache-mem.R
+++ b/tests/testthat/test-cache-mem.R
@@ -260,3 +260,19 @@ test_that("Pruned objects can be GC'd", {
   expect_true(finalized)
   expect_true(is.key_missing(mc$get("e")))
 })
+
+
+# For https://github.com/r-lib/cachem/issues/47, https://github.com/r-lib/cachem/pull/48/
+test_that("Cache doesn't grow beyond COMPACT_LIMIT", {
+  m <- cache_mem()
+  e <- environment(m$get)
+  n <- e$COMPACT_LIMIT + 1
+  for (i in seq_len(n)) {
+    m$set(as.character(i), i)
+    m$remove(as.character(i))
+  }
+  expect_equal(e$total_n_, 0)
+  # last_idx_ should be reset after we pass the COMPACT_LIMIT, even if there are
+  # no items in the cache. Prior to the fix in #48, it could keep growing.
+  expect_equal(e$last_idx_, 0)
+})

--- a/tests/testthat/test-cache-mem.R
+++ b/tests/testthat/test-cache-mem.R
@@ -263,16 +263,29 @@ test_that("Pruned objects can be GC'd", {
 
 
 # For https://github.com/r-lib/cachem/issues/47, https://github.com/r-lib/cachem/pull/48/
-test_that("Cache doesn't grow beyond COMPACT_LIMIT", {
+test_that("Cache doesn't shrink smaller than INITIAL_SIZE", {
+  # This test also makes sure that the cache doesn't keep adding elements to the
+  # storage vectors when there are zero items, then an item is added and
+  # removed, repeatedly.
   m <- cache_mem()
   e <- environment(m$get)
-  n <- e$COMPACT_LIMIT + 1
-  for (i in seq_len(n)) {
+  for (i in seq_len(e$INITIAL_SIZE)) {
     m$set(as.character(i), i)
     m$remove(as.character(i))
   }
   expect_equal(e$total_n_, 0)
-  # last_idx_ should be reset after we pass the COMPACT_LIMIT, even if there are
+  expect_equal(e$last_idx_, e$INITIAL_SIZE)
+  expect_length(e$key_, e$INITIAL_SIZE)
+  expect_length(e$value_, e$INITIAL_SIZE)
+
+  # Adding one more item should trigger a compact_()
+  m$set("a", 1)
+  m$remove("a")
+
+  expect_equal(e$total_n_, 0)
+  # last_idx_ should be reset after we pass the INITIAL_SIZE, even if there are
   # no items in the cache. Prior to the fix in #48, it could keep growing.
   expect_equal(e$last_idx_, 0)
+  expect_length(e$key_, e$INITIAL_SIZE)
+  expect_length(e$value_, e$INITIAL_SIZE)
 })


### PR DESCRIPTION
Closes #47.

Prior to this change, the internal cache objects could shrink smaller than `INITIAL_SIZE` or `COMPACT_LIMIT`. This PR:

- Removes `COMPACT_LIMIT` and just uses `INITIAL_SIZE` as the minimum size.
- Makes it so the storage vectors won't shrink smaller than `INITIAL_SIZE`.

This makes it so the `nothing to compact` message won't show up anymore.

This also requires the development version of fastmap, from after https://github.com/r-lib/fastmap/pull/39 was merged.
