### PR TITLE
Add "Supported By Posit" badge to cachem website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,5 @@ url: https://cachem.r-lib.org
 
 template:
   bootstrap: 5
+    in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the cachem website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of cachem website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/cachem-1200.png)

At 992px browser width:

![Screenshot of cachem website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/cachem-992.png)

At 991px browser width:

![Screenshot of cachem website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/cachem-991.png)

